### PR TITLE
pull-pico-change update: receiver sensitive poly resolution asSuper issue

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2101,14 +2101,14 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             ExpressionTree tree, ExecutableElement methodElt, AnnotatedTypeMirror receiverType) {
 
         AnnotatedExecutableType memberType = getAnnotatedType(methodElt); // get unsubstituted type
+        if (viewpointAdapter != null) {
+            viewpointAdapter.viewpointAdaptMethod(receiverType, methodElt, memberType);
+        }
         methodFromUsePreSubstitution(tree, memberType);
 
         AnnotatedExecutableType methodType =
                 AnnotatedTypes.asMemberOf(types, this, receiverType, methodElt, memberType);
         List<AnnotatedTypeMirror> typeargs = new ArrayList<>(methodType.getTypeVariables().size());
-        if (viewpointAdapter != null) {
-            viewpointAdapter.viewpointAdaptMethod(receiverType, methodElt, methodType);
-        }
 
         Map<TypeVariable, AnnotatedTypeMirror> typeVarMapping =
                 AnnotatedTypes.findTypeArguments(processingEnv, this, tree, methodElt, methodType);
@@ -2241,7 +2241,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         ExecutableElement ctor = TreeUtils.constructor(tree);
         AnnotatedTypeMirror type = fromNewClass(tree);
         addComputedTypeAnnotations(tree, type);
+
         AnnotatedExecutableType con = getAnnotatedType(ctor); // get unsubstituted type
+        if (viewpointAdapter != null) {
+            viewpointAdapter.viewpointAdaptConstructor(type, ctor, con);
+        }
         constructorFromUsePreSubstitution(tree, con);
 
         con = AnnotatedTypes.asMemberOf(types, this, type, ctor, con);
@@ -2256,9 +2260,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         }
 
         List<AnnotatedTypeMirror> typeargs = new ArrayList<>(con.getTypeVariables().size());
-        if (viewpointAdapter != null) {
-            viewpointAdapter.viewpointAdaptConstructor(type, ctor, con);
-        }
 
         Map<TypeVariable, AnnotatedTypeMirror> typeVarMapping =
                 AnnotatedTypes.findTypeArguments(processingEnv, this, tree, ctor, con);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2101,10 +2101,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             ExpressionTree tree, ExecutableElement methodElt, AnnotatedTypeMirror receiverType) {
 
         AnnotatedExecutableType memberType = getAnnotatedType(methodElt); // get unsubstituted type
+
+        methodFromUsePreSubstitution(tree, memberType);
         if (viewpointAdapter != null) {
             viewpointAdapter.viewpointAdaptMethod(receiverType, methodElt, memberType);
         }
-        methodFromUsePreSubstitution(tree, memberType);
 
         AnnotatedExecutableType methodType =
                 AnnotatedTypes.asMemberOf(types, this, receiverType, methodElt, memberType);
@@ -2243,10 +2244,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         addComputedTypeAnnotations(tree, type);
 
         AnnotatedExecutableType con = getAnnotatedType(ctor); // get unsubstituted type
+
+        constructorFromUsePreSubstitution(tree, con);
         if (viewpointAdapter != null) {
             viewpointAdapter.viewpointAdaptConstructor(type, ctor, con);
         }
-        constructorFromUsePreSubstitution(tree, con);
 
         con = AnnotatedTypes.asMemberOf(types, this, type, ctor, con);
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2102,6 +2102,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         AnnotatedExecutableType memberType = getAnnotatedType(methodElt); // get unsubstituted type
 
+        // since viewpoint adaption may introduce new poly annotation which should not be resolved,
+        // firstly do poly resolution
         methodFromUsePreSubstitution(tree, memberType);
         if (viewpointAdapter != null) {
             viewpointAdapter.viewpointAdaptMethod(receiverType, methodElt, memberType);

--- a/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
@@ -172,15 +172,17 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
                         javaReturntype instanceof Type.JCPrimitiveType
                                 || atypeFactory.types.isSubtype(javaReturntype, javaLhstype);
 
+                boolean polyIsSuper = atypeFactory.types.isSubtype(javaLhstype, javaReturntype);
+
                 // only perform receiver-sensitive poly resolution when return type is erased
                 // subtype of lhs
-                if (polyIsSub) {
+                if (polyIsSub || polyIsSuper) { // lhs and return type are comparable
                     instantiationMapping =
                             collector.reduceWithUpperBounds(
                                     instantiationMapping,
                                     collector.visit(
                                             // Actual assignment lhs type
-                                            assignmentContext, type.getReturnType(), true));
+                                            assignmentContext, type.getReturnType(), polyIsSub));
                 }
             }
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
@@ -172,7 +172,10 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
                         javaReturntype instanceof Type.JCPrimitiveType
                                 || atypeFactory.types.isSubtype(javaReturntype, javaLhstype);
 
-                boolean polyIsSuper = atypeFactory.types.isSubtype(javaLhstype, javaReturntype);
+                boolean polyIsSuper =
+                        !(javaReturntype instanceof Type.ArrayType)
+                                && // isSubtype cannot handle this
+                                atypeFactory.types.isSubtype(javaLhstype, javaReturntype);
 
                 // only perform receiver-sensitive poly resolution when return type is erased
                 // subtype of lhs


### PR DESCRIPTION
After introducing receiver-sensitive poly resolution (RSPS) and changing the substitution order, the originally fixed subtype relationship between assignment l-value and return value does not hold anymore (e.g. comparing with type variable upper bound). So, compare the subtyping relation before calling asSuper.

TODO: when subtyping relation between assignment l-value and return value is undecidable, i.e. neither subtype nor supertype. Currently skipped RSPS for such case. So far the only known case is when returning type is a type var instantiated with a intersection:

```
interface I {}

class MyClass<T> {
    public T get() {...}
}

class Main {
    public <V extends Enum & I> foo(MyClass<V> myc) {
        I i = myc.get();  // l-value (I) and return value (T extends Object super null) neither subtype nor supertype
    }
}
```