### PR TITLE
pull-pico-changes update: getAssignmentContext for typevar inference

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1,6 +1,7 @@
 package org.checkerframework.common.value;
 
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1255,6 +1255,35 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     public AnnotatedTypeMirror getDummyAssignedTo(ExpressionTree expressionTree) {
         TypeMirror type = TreeUtils.typeOf(expressionTree);
         if (type.getKind() != TypeKind.VOID) {
+            TreePath pathToExpression = getPath(expressionTree);
+            // if the assignment context exists but not usable by type inference, return upper bound
+            if (pathToExpression != null
+                    && TreeUtils.getAssignmentContext(pathToExpression, true) == null
+                    && TreeUtils.getAssignmentContext(pathToExpression) != null) {
+                Tree grandTree = pathToExpression.getParentPath().getParentPath().getLeaf();
+                if (grandTree instanceof MethodInvocationTree) {
+                    ExecutableElement methodElt =
+                            TreeUtils.elementFromUse((MethodInvocationTree) grandTree);
+                    AnnotatedTypeMirror.AnnotatedDeclaredType declReceiverType =
+                            getAnnotatedType(methodElt).getReceiverType();
+                    if (declReceiverType != null) {
+                        ArrayList<AnnotatedTypeMirror> typeVarUpperBounds =
+                                new ArrayList<>(declReceiverType.getTypeArguments().size());
+                        for (AnnotatedTypeMirror tv : declReceiverType.getTypeArguments()) {
+                            if (tv instanceof AnnotatedTypeMirror.AnnotatedTypeVariable) {
+                                typeVarUpperBounds.add(
+                                        ((AnnotatedTypeMirror.AnnotatedTypeVariable) tv)
+                                                .getUpperBound());
+                            }
+                        }
+                        declReceiverType.setTypeArguments(
+                                Collections.unmodifiableList(typeVarUpperBounds));
+                    }
+
+                    return declReceiverType;
+                }
+                //                return null;
+            }
             AnnotatedTypeMirror atm = type(expressionTree);
             addDefaultAnnotations(atm);
             return atm;

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -139,7 +139,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
         if (TreeUtils.enclosingNonParen(pathToExpression).first.getKind()
                         == Tree.Kind.LAMBDA_EXPRESSION
                 || (assignedTo == null
-                        && TreeUtils.getAssignmentContext(pathToExpression) != null)) {
+                        && TreeUtils.getAssignmentContext(pathToExpression, true) != null)) {
             // If the type of the assignment context isn't found, but the expression is assigned,
             // then don't attempt to infer type arguments, because the Java type inferred will be
             // incorrect.  The assignment type is null when it includes uninferred type arguments.

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -434,6 +434,15 @@ public final class TreeUtils {
                 TreePath grandParentPath = parentPath.getParentPath();
                 if (grandParentPath != null
                         && grandParentPath.getLeaf() instanceof MethodInvocationTree) {
+                    MethodInvocationTree grandTree =
+                            (MethodInvocationTree) grandParentPath.getLeaf();
+
+                    // adapted from TypeArgInferenceUtil#assignedTo to be consistent
+                    if (grandTree.getMethodSelect() instanceof MemberSelectTree
+                            && ((MemberSelectTree) grandTree.getMethodSelect()).getExpression()
+                                    == treePath.getLeaf()) {
+                        return null;
+                    }
                     return grandParentPath.getLeaf();
                 } else {
                     return null;


### PR DESCRIPTION
Added another `getAssignmentContext` for typevar inference only, since assignment context with circular dependency is not usable for typevar inference, e.g. for `foo().bar()` scheme, "l-value" of `foo()` depends on the returning value of `bar()` which again depends on the returning value of `foo()` for recevier.

For value checker only: update the `getDummyAssignedTo` to adapt the changes, using the upper bound for default. Only this checker generates a dummy, other checkers just use null, so no changes needed.